### PR TITLE
Add Celo blockchain chainIds and rpc urls

### DIFF
--- a/src/hooks/useInitializeOnboard.ts
+++ b/src/hooks/useInitializeOnboard.ts
@@ -125,6 +125,11 @@ const initOnboard = (subscriptions, walletConfig) => {
   const walletConnectOptions = {
     infuraKey: INFURA_ID,
     preferred: true,
+    rpc: {
+      42220: 'https://forno.celo.org',
+      44787: 'https://alfajores-forno.celo-testnet.org',
+      62320: 'https://baklava-forno.celo-testnet.org'
+    },
     bridge: 'https://pooltogether.bridge.walletconnect.org/'
   }
 


### PR DESCRIPTION
Hey,

I'm adding support for PoolTogether in Valora via WalletConnect.

This change was needed to make WalletConnect work.

This also depends on https://github.com/pooltogether/onboard/pull/4

Let me know what you think.